### PR TITLE
Mira Security Logger Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ You will have to change those values by other means (using memory editing or for
 ## Installation
 See: [client installation](https://github.com/CrowdedMods/CrowdedMod/wiki/Client-Installation)
 
+## TO-DO
+- switch to [semantic versioning](https://semver.org/)
+
 ## Credits
 - [andry08/100-player-mod](https://github.com/andry08/100-player-mod) - Original author of this plugin. RayanTheBest/100-player-mod was a mirror of this, now we have an official link.
 - [andruzzzhka/CustomServersClient](https://github.com/andruzzzhka/CustomServersClient) - This is where andry08 and i learned how to mod Among Us. Some snippets of code for custom servers are here.

--- a/RemovePlayerLimit/GenericPatches.cs
+++ b/RemovePlayerLimit/GenericPatches.cs
@@ -138,7 +138,7 @@ namespace CrowdedMod {
         {
             public static void Postfix(VersionShower __instance)
             {
-                __instance.text.Text = "Among Us " + __instance.text.Text + " \n[3DAD2BFF]Crowded Mod v3.5 by Przebot#2448 \nForked from andry08";
+                __instance.text.Text = "Among Us " + __instance.text.Text + " \n[3DAD2BFF]Crowded Mod v3.6 by Przebot#2448 \nForked from andry08";
                 if(parseStatus != ServersParser.ParseResult.Success)
                 {
                     __instance.text.Text += $"\n\n{parseErrorMessages[parseStatus]}";

--- a/RemovePlayerLimit/RemovePlayerLimit.csproj
+++ b/RemovePlayerLimit/RemovePlayerLimit.csproj
@@ -87,6 +87,7 @@
     <Compile Include="GenericPatches.cs" />
     <Compile Include="RemovePlayerLimitPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SecurityLogPatches.cs" />
     <Compile Include="ServersParser.cs" />
     <Compile Include="VitalsPatches.cs" />
   </ItemGroup>

--- a/RemovePlayerLimit/RemovePlayerLimitPlugin.cs
+++ b/RemovePlayerLimit/RemovePlayerLimitPlugin.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 using System.Linq;
 using System.Reflection;
 namespace CrowdedMod {
-    [BepInPlugin("pl.przebor.crowded", "Crowded Mod", "3.5")]
+    [BepInPlugin("pl.przebor.crowded", "Crowded Mod", "3.6")]
     public class RemovePlayerLimitPlugin : BasePlugin {
 
         static internal BepInEx.Logging.ManualLogSource Logger;

--- a/RemovePlayerLimit/SecurityLogPatches.cs
+++ b/RemovePlayerLimit/SecurityLogPatches.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using SecurityLogger = MAOCFFOEGFE;
+
+namespace CrowdedMod
+{
+    class SecurityLogPatches
+    {
+        [HarmonyPatch(typeof(SecurityLogger), nameof(SecurityLogger.Awake))]
+        public static class SecurityLoggerPatch
+        {
+            public static void Postfix(ref SecurityLogger __instance)
+            {
+                __instance.KJGAJKDMDHJ = new float[127]; // Timers
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes security logger on Mira for players with IDs higher than 9. (bug was caused by the cooldown array which was limited to 10 elements).
Also bumped version and added TO-DO.