### PR TITLE
Fixed Issue #51

### DIFF
--- a/src/CrowdedMod/Patches/GenericPatches.cs
+++ b/src/CrowdedMod/Patches/GenericPatches.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using AmongUs.GameOptions;
 using CrowdedMod.Net;
 using HarmonyLib;
@@ -16,12 +16,11 @@ namespace CrowdedMod.Patches {
             }
         }
 
-        [HarmonyPatch(typeof(PlayerTab), nameof(PlayerTab.IsSelectedItemEquipped))]
+        [HarmonyPatch(typeof(PlayerTab), nameof(PlayerTab.Update))]
         public static class PlayerTabIsSelectedItemEquippedPatch {
-            public static bool Prefix(out bool __result)
+            public static void Postfix(PlayerTab __instance)
             {
-                __result = true;
-                return false;
+                __instance.currentColorIsEquipped = false;
             }
         }
 


### PR DESCRIPTION
I'm not entirely sure what causes this to occur, but any `PassiveButton` press causes `PlayerTab.IsSelectedItemEquipped()` to fire with a non-existent component attached to the button. This is likely a bug with BepInEx. This PR replaces that snippet with a postfix that edits `PlayerTab.currentColorIsEquipped` instead.