### PR TITLE
Fix: Lag in SecurityLogger.Awake

### DIFF
--- a/src/CrowdedMod/Patches/MiniGamePatches.cs
+++ b/src/CrowdedMod/Patches/MiniGamePatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 
 namespace CrowdedMod.Patches;
 
@@ -9,7 +10,7 @@ internal static class MiniGamePatches
     {
         public static void Postfix(SecurityLogger __instance)
         {
-            __instance.Timers = new float[CrowdedModPlugin.MaxPlayers];
+            __instance.Timers = new Il2CppStructArray<float>(CrowdedModPlugin.MaxPlayers);
         }
     }
 }


### PR DESCRIPTION
Instead of `float[]` it is better to use `Il2CppStructArray<float>()`
Since the `System` converting in `Il2CppInterop` (or `Il2CppSystem`) causes a strong lag, it is better to use `Il2CppStructArray<float>()`