### PR TITLE
Improve : MeetingHudPagingBehaviour

### DIFF
--- a/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
+++ b/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
@@ -17,7 +17,19 @@ public class MeetingHudPagingBehaviour : AbstractPagingBehaviour
     internal MeetingHud meetingHud = null!;
 
     [HideFromIl2Cpp] public IEnumerable<PlayerVoteArea> Targets => meetingHud.playerStates.OrderBy(p => p.AmDead);
-    public override int MaxPageIndex => (Targets.Count() - 1) / MaxPerPage;
+    public override int MaxPageIndex
+    {
+        get
+        {
+            if (maxPageIndex == -1)
+            {
+                maxPageIndex = (Targets.Count() - 1) / MaxPerPage;
+            }
+            return maxPageIndex;
+        }
+    }
+
+    private int maxPageIndex = -1;
 
     public override void Start() => OnPageChanged();
 

--- a/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
+++ b/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
@@ -16,7 +16,19 @@ public class MeetingHudPagingBehaviour : AbstractPagingBehaviour
 
     internal MeetingHud meetingHud = null!;
 
-    [HideFromIl2Cpp] public IEnumerable<PlayerVoteArea> Targets => meetingHud.playerStates.OrderBy(p => p.AmDead);
+    [HideFromIl2Cpp] public IEnumerable<PlayerVoteArea> Targets
+    {
+        get
+        {
+            if (targets == null)
+            {
+                targets = meetingHud.playerStates.OrderBy(p => p.AmDead);
+            }
+            return targets;
+        }
+    }
+    private IEnumerable<PlayerVoteArea>? targets;
+
     public override int MaxPageIndex
     {
         get
@@ -28,7 +40,6 @@ public class MeetingHudPagingBehaviour : AbstractPagingBehaviour
             return maxPageIndex;
         }
     }
-
     private int maxPageIndex = -1;
 
     public override void Start() => OnPageChanged();

--- a/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
+++ b/src/CrowdedMod/Components/MeetingHudPagingBehaviour.cs
@@ -22,12 +22,12 @@ public class MeetingHudPagingBehaviour : AbstractPagingBehaviour
         {
             if (targets == null)
             {
-                targets = meetingHud.playerStates.OrderBy(p => p.AmDead);
+                targets = meetingHud.playerStates.OrderBy(p => p.AmDead).ToArray();
             }
             return targets;
         }
     }
-    private IEnumerable<PlayerVoteArea>? targets;
+    private PlayerVoteArea[]? targets;
 
     public override int MaxPageIndex
     {


### PR DESCRIPTION
#58 is also included.

Problems with current
  - The calculation of `O(n^2)` is occurring(`.OrderBy` and `.Count` are `O(n)`) every frame due to `MaxPageIndex` being called every frame, it's not a problem with a dozen or so players, but as the number of players increases, it will become a noticeable lag
  - `Targets` are recalculated when pages are changed, so if you change pages when a kill occurs during a meeting, such as the ability of a mod's role, the order of `PlayerVoteArea` position will change.
    - This would change the position of the vote and cause confusion.

This PR has made the following changes
 - `MaxPageIndex` calculation is cached and changed to one time `O(n^2)` calculation (drops to `O(n)` if `Targets` are cached)
 - `Targets` is cached and changed to lazy to eager evaluation, so that the order doesn't change.
