### PR TITLE
feat: Remove Default Server logics

### DIFF
--- a/src/CrowdedMod/CrowdedModPlugin.cs
+++ b/src/CrowdedMod/CrowdedModPlugin.cs
@@ -49,8 +49,9 @@ public partial class CrowdedModPlugin : BasePlugin
     }
 
     private static bool IsVanillaServer(IRegionInfo regionInfo)
-        => regionInfo.TranslateName is
-            StringNames.ServerAS or
-            StringNames.ServerEU or
-            StringNames.ServerNA;
+        => regionInfo != null &&
+        regionInfo.TranslateName is
+        StringNames.ServerAS or
+        StringNames.ServerEU or
+        StringNames.ServerNA;
 }

--- a/src/CrowdedMod/CrowdedModPlugin.cs
+++ b/src/CrowdedMod/CrowdedModPlugin.cs
@@ -5,6 +5,7 @@ using Reactor;
 using Reactor.Networking;
 using Reactor.Networking.Attributes;
 using Reactor.Utilities;
+using System.Linq;
 
 namespace CrowdedMod;
 
@@ -27,5 +28,29 @@ public partial class CrowdedModPlugin : BasePlugin
         ReactorCredits.Register<CrowdedModPlugin>(ReactorCredits.AlwaysShow);
 
         Harmony.PatchAll();
+
+        RemoveVanillaServer();
     }
+
+    public static void RemoveVanillaServer()
+    {
+        var sm = ServerManager.Instance;
+        var curRegions = sm.AvailableRegions;
+        sm.AvailableRegions = curRegions.Where(region => !IsVanillaServer(region)).ToArray();
+
+        var defaultRegion = ServerManager.DefaultRegions;
+        ServerManager.DefaultRegions = defaultRegion.Where(region => !IsVanillaServer(region)).ToArray();
+
+        if (IsVanillaServer(sm.CurrentRegion))
+        {
+            var region = defaultRegion.FirstOrDefault();
+            sm.SetRegion(region);
+        }
+    }
+
+    private static bool IsVanillaServer(IRegionInfo regionInfo)
+        => regionInfo.TranslateName is
+            StringNames.ServerAS or
+            StringNames.ServerEU or
+            StringNames.ServerNA;
 }

--- a/src/CrowdedMod/Patches/GenericPatches.cs
+++ b/src/CrowdedMod/Patches/GenericPatches.cs
@@ -113,7 +113,7 @@ internal static class GenericPatches
 
         public static void Postfix(GameStartManager __instance)
         {
-            if (string.IsNullOrEmpty(fixDummyCounterColor) || 
+            if (string.IsNullOrEmpty(fixDummyCounterColor) ||
                 GameData.Instance == null ||
                 GameManager.Instance?.LogicOptions == null)
             {
@@ -167,7 +167,7 @@ internal static class GenericPatches
             return false;
         }
     }
-    
+
     private static void TryAdjustOptionsRecommendations(GameOptionsManager manager)
     {
         const int MaxPlayers = CrowdedModPlugin.MaxPlayers;
@@ -181,7 +181,7 @@ internal static class GenericPatches
         var killRecommendation = ((Il2CppStructArray<int>)Enumerable.Repeat(0, MaxPlayers + 1).ToArray())
             .Cast<Il2CppSystem.Object>();
 
-            
+
         const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
         // all these fields are currently static, but we're doing a forward compat
         // static fields ignore object param so non-null instance is ok
@@ -207,7 +207,7 @@ internal static class GenericPatches
             }
         }
     }
-    
+
     [HarmonyPatch(typeof(GameOptionsManager), nameof(GameOptionsManager.SwitchGameMode))]
     public static class GameOptionsManager_SwitchGameMode
     {
@@ -240,6 +240,15 @@ internal static class GenericPatches
                     }
                 }
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(MainMenuManager), nameof(MainMenuManager.Start))]
+    public static class RemoveVanillaServerPatch
+    {
+        public static void Postfix()
+        {
+            CrowdedModPlugin.RemoveVanillaServer();
         }
     }
 }


### PR DESCRIPTION
Add logic to removing official servers on the mod side
To prevent any trouble from connecting to the official servers of AmongUs with this mod installed