### PR TITLE
Fix : some null bug

### DIFF
--- a/src/CrowdedMod/Patches/GenericPatches.cs
+++ b/src/CrowdedMod/Patches/GenericPatches.cs
@@ -16,6 +16,7 @@ namespace CrowdedMod.Patches;
 internal static class GenericPatches
 {
     private static bool ShouldDisableColorPatch => CrowdedModPlugin.ForceDisableFreeColor ||
+                                                   GameData.Instance == null ||
                                                    GameData.Instance.PlayerCount <= Palette.PlayerColors.Length;
 
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.CmdCheckColor))]
@@ -113,9 +114,10 @@ internal static class GenericPatches
 
         public static void Postfix(GameStartManager __instance)
         {
-            if (string.IsNullOrEmpty(fixDummyCounterColor) || 
+            if (string.IsNullOrEmpty(fixDummyCounterColor) ||
                 GameData.Instance == null ||
-                GameManager.Instance?.LogicOptions == null)
+                GameManager.Instance == null ||
+                GameManager.Instance.LogicOptions == null)
             {
                 return;
             }
@@ -167,7 +169,7 @@ internal static class GenericPatches
             return false;
         }
     }
-    
+
     private static void TryAdjustOptionsRecommendations(GameOptionsManager manager)
     {
         const int MaxPlayers = CrowdedModPlugin.MaxPlayers;
@@ -181,7 +183,7 @@ internal static class GenericPatches
         var killRecommendation = ((Il2CppStructArray<int>)Enumerable.Repeat(0, MaxPlayers + 1).ToArray())
             .Cast<Il2CppSystem.Object>();
 
-            
+
         const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
         // all these fields are currently static, but we're doing a forward compat
         // static fields ignore object param so non-null instance is ok
@@ -207,7 +209,7 @@ internal static class GenericPatches
             }
         }
     }
-    
+
     [HarmonyPatch(typeof(GameOptionsManager), nameof(GameOptionsManager.SwitchGameMode))]
     public static class GameOptionsManager_SwitchGameMode
     {


### PR DESCRIPTION
Fixed bug related to null

 - Null error on color selection screen in title
 - Warning due to Unity overriding the null conditional operator([UNT0008](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0008.md))